### PR TITLE
[REF] Simplify workflow

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,7 @@ RUN apt-get update -qq \
                                                      gcc \
                                                      pigz \
                                                      curl \
+                                                     datalad \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/bidsify/bidsify.py
+++ b/bidsify/bidsify.py
@@ -88,12 +88,8 @@ def bidsify_workflow(dicomdir, heuristic, subject, session=None,
             raise ValueError('Heudiconv currently only accepts '
                              '.tar and .tar.gz inputs')
         dir_type = '-d'
-        heudiconv_input = dcm_name.replace(subject, '{subject}')
-        if session:
-            heudiconv_input = heudiconv_input.replace(session, '{session}')
     elif dicomdir.is_dir():
         dir_type = '--files'
-        heudiconv_input = str(dicomdir.as_posix())
     else:
         raise ValueError('dicomdir must be a tarball '
                          'or directory containing dicoms')

--- a/bidsify/bidsify.py
+++ b/bidsify/bidsify.py
@@ -115,10 +115,9 @@ def bidsify_workflow(dicomdir, heuristic, subject, session=None,
 
     if work_dir is None:
         work_dir = output_dir / '.tmp'
-
-    work_dir = work_dir / subject
-    if session:
-        work_dir = work_dir / session
+        work_dir = work_dir / subject
+        if session:
+            work_dir = work_dir / session
     work_dir.mkdir(parents=True, exist_ok=True)
 
     if not (output_dir / '.bidsignore').is_file():
@@ -153,10 +152,10 @@ def bidsify_workflow(dicomdir, heuristic, subject, session=None,
 
     # Run BIDS validator
     cmd = (f'bids-validator {output_dir} --ignoreWarnings > '
-           f'{output_dir / "validator.txt"}')
+           f'{work_dir / "validator.txt"}')
     run(cmd, env={'TMPDIR': work_dir.name})
 
-    # Clean up output directory, returning it to bids standard
+    # Remove temporary subfolders from output directory
     maintain_bids(output_dir, subject, session)
 
     # Grab some info from the dicoms to add to the participants file

--- a/bidsify/bidsify.py
+++ b/bidsify/bidsify.py
@@ -126,7 +126,7 @@ def bidsify_workflow(dicomdir, heuristic, subject, session=None,
             fo.write('\n'.join(to_ignore))
 
     # Run heudiconv
-    if dir_type = 'tarball':
+    if dir_type == 'tarball':
         heudiconv(dicom_dir_template=dicomdir, subjs=subject,
                   heuristic=heuristic, converter='dcm2niix',
                   outdir=output_dir, bids_options=True, overwrite=True,

--- a/bidsify/bidsify.py
+++ b/bidsify/bidsify.py
@@ -7,6 +7,7 @@ from dateutil.parser import parse
 
 import numpy as np
 import pandas as pd
+from heudiconv.main import workflow as heudiconv
 from bidsutils.metadata import complete_jsons, clean_metadata
 # Local imports
 from bidsify.utils import run, manage_dicomdir, maintain_bids
@@ -42,10 +43,17 @@ def _get_parser():
                         required=True,
                         metavar='PATH',
                         help='Output directory')
+    parser.add_argument('--datalad',
+                        type=bool,
+                        required=False,
+                        action='store_true',
+                        default=False,
+                        help='Use datalad to track changes to dataset.')
     return parser
 
 
-def bidsify_workflow(dicomdir, heuristic, subject, session=None, output_dir='.'):
+def bidsify_workflow(dicomdir, heuristic, subject, session=None,
+                     output_dir='.', datalad=False):
     """Run the BIDSification workflow.
 
     This workflow (1) runs heudiconv to convert dicoms to nifti BIDS format,
@@ -66,6 +74,8 @@ def bidsify_workflow(dicomdir, heuristic, subject, session=None, output_dir='.')
     output_dir : str, optional
         Directory to output bidsified data. Default is '.' (current working
         directory).
+    datalad : bool, optional
+        Whether to use datalad or not. Default is False.
     """
     # Heuristic may be file or heudiconv builtin
     # Use existence of file extension to determine if builtin or file
@@ -102,10 +112,16 @@ def bidsify_workflow(dicomdir, heuristic, subject, session=None, output_dir='.')
             wk_file.write('.heudiconv/\n.tmp/\nvalidator.txt\n')
 
     # Run heudiconv
-    cmd = (f'heudiconv {dir_type} {dicomdir} '
-           f'-s {subject} -f {heuristic} -c dcm2niix '
-           f'-o {output_dir} --bids --overwrite --minmeta')
-    run(cmd, env={'TMPDIR': tmp_path.name})
+    if dir_type = '-d':
+        heudiconv(dicom_dir_template=dicomdir, subjs=subject,
+                  heuristic=heuristic, converter='dcm2niix', outdir=output_dir,
+                  bids_options=True, overwrite=True, minmeta=True,
+                  datalad=datalad, with_prov=True)
+    else:
+        heudiconv(files=dicomdir, subjs=subject,
+                  heuristic=heuristic, converter='dcm2niix', outdir=output_dir,
+                  bids_options=True, overwrite=True, minmeta=True,
+                  datalad=datalad, with_prov=True)
 
     # Run defacer
     anat_files = sub_dir.glob('/anat/*.nii.gz')

--- a/bidsify/utils.py
+++ b/bidsify/utils.py
@@ -38,12 +38,17 @@ def run(command, env=None):
     return process.returncode
 
 
-def manage_dicomdir(dicomdir):
+def load_dicomdir_metadata(dicomdir):
     """Grab data from dicom directory of a given type (tar, tar.gz, directory).
 
     Parameters
     ----------
     dicomdir: Directory containing dicoms for processing
+
+    Returns
+    -------
+    data : dicom header
+        DICOM information from first dicom in directory.
     """
     if dicomdir.is_file() and dicomdir.suffix in ('.gz', '.tar'):
         open_type = 'r'
@@ -61,10 +66,10 @@ def manage_dicomdir(dicomdir):
     return data
 
 
-def maintain_bids(output_dir, sub, ses):
-    """Clean up a working directory and make it BIDS standard.
+def clean_tempdirs(output_dir, sub, ses):
+    """Clean up working directories (.heudiconv and .tmp).
 
-    Clean up working directories. If all work is complete, this will return the
+    If all work is complete, this will return the
     directory to BIDS standard (removing .heudiconv and .tmp directories).
 
     Parameters

--- a/bidsify/utils.py
+++ b/bidsify/utils.py
@@ -65,7 +65,7 @@ def maintain_bids(output_dir, sub, ses):
     """Clean up a working directory and make it BIDS standard.
 
     Clean up working directories. If all work is complete, this will return the
-    directory to BIDS standard (removing .heudiconv and tmp directories).
+    directory to BIDS standard (removing .heudiconv and .tmp directories).
 
     Parameters
     ----------

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ install_requires =
     pandas
     pybids>=0.10.2
     bidsutils @ git+https://github.com/FIU-Neuro/cis-bidsutils.git
-    heudiconv>=0.7.0
+    heudiconv @ git+https://github.com/nipy/heudiconv.git
 
 [options.extras_require]
 duecredit = duecredit


### PR DESCRIPTION
Closes #33. Related to https://github.com/fiuneuro/cis-processing/issues/64 and https://github.com/fiuneuro/cis-processing/pull/66.

The assumption for future usage is that the image will have access to the full dataset. This can be achieved by running the image _from_ a parent directory of the dataset, in cases where some folders cannot be bound via normal means (e.g., `/data`).

Changes proposed:
- Switch heudiconv call from CLI to Python function.
- Support datalad.
- Install datalad in Dockerfile.