### PR TITLE
[FIX] Fix argparser construction

### DIFF
--- a/bidsify/bidsify.py
+++ b/bidsify/bidsify.py
@@ -53,7 +53,6 @@ def _get_parser():
                         default=None,
                         help='Working directory (in scratch).')
     parser.add_argument('--datalad',
-                        type=bool,
                         required=False,
                         action='store_true',
                         default=False,


### PR DESCRIPTION
This fixes a bug introduced recently by me, in which the `type` argument is provided to an `argparse` argument when it's not allowed. Going to push this through ASAP.