### PR TITLE
[FIX] Fix Issue in 'tempdir' cleaning, defacing of symlinked files

### DIFF
--- a/bidsify/bidsify.py
+++ b/bidsify/bidsify.py
@@ -181,7 +181,7 @@ def bidsify_workflow(dicomdir, heuristic, subject, session=None,
     json_files = list(sub_dir.glob('*/*.json'))
     tsv_files = list(sub_dir.glob('*/*.tsv'))
     for f in (nii_files + json_files + tsv_files):
-        os.chmod(f, 0o664)
+        os.chmod(os.path.realpath(f), 0o664)
 
     # Run defacer
     anat_files = sub_dir.glob('anat/*.nii.gz')


### PR DESCRIPTION
This PR should fix a few lingering lingering issues, namely #55 and #57.

Changes:
* Use `realpath` of file object when applying `os.chmod()` prior to defacing
* Fix `tempdir` cleaning of bids directory.

Closes #55, closes #57 
